### PR TITLE
Implement changes suggested during the 2nd review

### DIFF
--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -43,10 +43,11 @@ const authenticate = {
           message: 'Authentication failed: User not found'
         });
       }
-    }).catch(() => {
+    }).catch((err) => {
       res.status(500).json({
         success: false,
-        message: 'Server error'
+        message: 'Server error',
+        error: err
       });
     });
   },

--- a/controllers/documents.js
+++ b/controllers/documents.js
@@ -118,11 +118,7 @@ const documentsCtr = {
     const decodedUser = req.decoded;
     const docId = req.params.id;
 
-    docModel.findOne({
-      where: {
-        id: docId
-      }
-    }).then((document) => {
+    docModel.findById(docId).then((document) => {
       if (document) {
         if (document.ownerId === decodedUser.id || document.access === 'public') {
           res.status(200).json({
@@ -204,11 +200,7 @@ const documentsCtr = {
     models.Roles.findById(decodedUser.roleId)
     .then((role) => {
       if (role) {
-        docModel.findOne({
-          where: {
-            id: docId
-          }
-        }).then((document) => {
+        docModel.findById(docId).then((document) => {
           if (role.title === 'admin' || document.ownerId === decodedUser.id) {
             docModel.update(docEdit, {
               where: {
@@ -263,11 +255,7 @@ const documentsCtr = {
     models.Roles.findById(decodedUser.roleId)
     .then((role) => {
       if (role) {
-        docModel.findOne({
-          where: {
-            id: docId
-          }
-        }).then((document) => {
+        docModel.findById(docId).then((document) => {
           if (role.title === 'admin' || document.ownerId === decodedUser.id) {
             docModel.destroy({
               where: {
@@ -324,11 +312,7 @@ const documentsCtr = {
     const uid = req.params.uid;
     const userRoleId = decoded.roleId;
 
-    models.Roles.findOne({
-      where: {
-        id: userRoleId
-      }
-    }).then((role) => {
+    models.Roles.findById(userRoleId).then((role) => {
       if (!role) {
         res.status(404).json({
           success: false,

--- a/controllers/documents.js
+++ b/controllers/documents.js
@@ -1,5 +1,7 @@
 const models = require('./../models/');
-const dotenv = require('dotenv').config({ silent: true });
+const dotenv = require('dotenv').config({
+  silent: true
+});
 const docHelper = require('./helpers/docHelper.js');
 
 const docModel = models.Documents;
@@ -13,51 +15,46 @@ const documentsCtr = {
     models.Roles
       .findById(decodedUser.roleId)
       .then((role) => {
-        if (role) {
-          if (role.title !== 'admin') {
-            if (dbQuery['where']) {
-              dbQuery['where']['$or'] = [
-                { access: 'public' },
-                { ownerId: decodedUser.id }
-              ];
-            } else {
-              dbQuery.where = {
-                $or: [
-                  { access: 'public' },
-                  { ownerId: decodedUser.id },
-                ]
-              };
-            }
+        if (role.title !== 'admin') {
+          if (dbQuery['where']) {
+            dbQuery['where']['$or'] = [{
+              access: 'public'
+            }, {
+              ownerId: decodedUser.id
+            }];
+          } else {
+            dbQuery.where = {
+              $or: [{
+                access: 'public'
+              }, {
+                ownerId: decodedUser.id
+              }, ]
+            };
           }
-
-          docModel.findAll(dbQuery)
-            .then((documents) => {
-              if (documents.length > 0) {
-                res.status(200).json({
-                  success: true,
-                  message: 'Documents retreived',
-                  data: documents
-                });
-              } else {
-                res.status(200).json({
-                  success: true,
-                  message: 'No documents available',
-                  data: []
-                });
-              }
-            }).catch((err) => {
-              res.status(500).json({
-                success: false,
-                message: 'Server error',
-                error: err
-              });
-            });
-        } else {
-          res.status(404).json({
-            success: false,
-            message: 'Role not found'
-          });
         }
+
+        docModel.findAll(dbQuery)
+          .then((documents) => {
+            if (documents.length > 0) {
+              res.status(200).json({
+                success: true,
+                message: 'Documents retreived',
+                data: documents
+              });
+            } else {
+              res.status(200).json({
+                success: true,
+                message: 'No documents available',
+                data: []
+              });
+            }
+          }).catch((err) => {
+            res.status(500).json({
+              success: false,
+              message: 'Server error',
+              error: err
+            });
+          });
       }).catch((err) => {
         res.status(500).json({
           success: false,
@@ -129,45 +126,38 @@ const documentsCtr = {
         } else {
           models.Roles.findById(decodedUser.roleId)
             .then((role) => {
-              if (role) {
-                if (role.title === 'admin') {
-                  res.status(200).json({
-                    success: true,
-                    message: 'Document found',
-                    data: document
-                  });
-                } else if (document.access === 'role') {
-                  models.Users.findById(document.ownerId)
-                    .then((user) => {
-                      if (user.roleId === decodedUser.roleId) {
-                        res.status(200).json({
-                          success: true,
-                          message: 'Document found',
-                          data: document
-                        });
-                      } else {
-                        res.status(403).json({
-                          success: false,
-                          message: 'You\'re not authorised to access this document'
-                        });
-                      }
-                    }).catch((err) => {
-                      res.status(500).json({
-                        success: false,
-                        message: 'Server error',
-                        error: err
+              if (role.title === 'admin') {
+                res.status(200).json({
+                  success: true,
+                  message: 'Document found',
+                  data: document
+                });
+              } else if (document.access === 'role') {
+                models.Users.findById(document.ownerId)
+                  .then((user) => {
+                    if (user.roleId === decodedUser.roleId) {
+                      res.status(200).json({
+                        success: true,
+                        message: 'Document found',
+                        data: document
                       });
+                    } else {
+                      res.status(403).json({
+                        success: false,
+                        message: 'You\'re not authorised to access this document'
+                      });
+                    }
+                  }).catch((err) => {
+                    res.status(500).json({
+                      success: false,
+                      message: 'Server error',
+                      error: err
                     });
-                } else {
-                  res.status(403).json({
-                    success: false,
-                    message: 'You\'re not authorised to access this document'
                   });
-                }
               } else {
-                res.status(404).json({
+                res.status(403).json({
                   success: false,
-                  message: 'Role not found'
+                  message: 'You\'re not authorised to access this document'
                 });
               }
             }).catch((err) => {
@@ -198,8 +188,7 @@ const documentsCtr = {
     const docId = req.params.id;
 
     models.Roles.findById(decodedUser.roleId)
-    .then((role) => {
-      if (role) {
+      .then((role) => {
         docModel.findById(docId).then((document) => {
           if (role.title === 'admin' || document.ownerId === decodedUser.id) {
             docModel.update(docEdit, {
@@ -234,27 +223,20 @@ const documentsCtr = {
             error: err
           });
         });
-      } else {
-        res.status(404).json({
+      }).catch((err) => {
+        res.status(500).json({
           success: false,
-          message: 'Role not found'
+          message: 'Server error',
+          error: err
         });
-      }
-    }).catch((err) => {
-      res.status(500).json({
-        success: false,
-        message: 'Server error',
-        error: err
       });
-    });
   },
   delete: (req, res) => {
     const decodedUser = req.decoded;
     const docId = req.params.id;
 
     models.Roles.findById(decodedUser.roleId)
-    .then((role) => {
-      if (role) {
+      .then((role) => {
         docModel.findById(docId).then((document) => {
           if (role.title === 'admin' || document.ownerId === decodedUser.id) {
             docModel.destroy({
@@ -293,19 +275,13 @@ const documentsCtr = {
             error: err
           });
         });
-      } else {
-        res.status(404).json({
+      }).catch((err) => {
+        res.status(500).json({
           success: false,
-          message: 'Role not found'
+          message: 'Server error',
+          error: err
         });
-      }
-    }).catch((err) => {
-      res.status(500).json({
-        success: false,
-        message: 'Server error',
-        error: err
       });
-    });
   },
   getUserDoc: (req, res) => {
     const decoded = req.decoded;
@@ -313,43 +289,36 @@ const documentsCtr = {
     const userRoleId = decoded.roleId;
 
     models.Roles.findById(userRoleId).then((role) => {
-      if (!role) {
-        res.status(404).json({
-          success: false,
-          message: 'Role doesn\'t exists'
+      if (decoded.id === Number(uid) || role.title === 'admin') {
+        docModel.findAll({
+          where: {
+            ownerId: uid
+          }
+        }).then((documents) => {
+          if (documents.length > 0) {
+            res.status(200).json({
+              success: true,
+              message: 'Documents retrieved',
+              data: documents
+            });
+          } else {
+            res.status(200).json({
+              success: true,
+              message: 'User doesn\'t have any document',
+              data: []
+            });
+          }
+        }).catch(() => {
+          res.status(500).json({
+            success: false,
+            message: 'Server error'
+          });
         });
       } else {
-        if (decoded.id === Number(uid) || role.title === 'admin') {
-          docModel.findAll({
-            where: {
-              ownerId: uid
-            }
-          }).then((documents) => {
-            if (documents.length > 0) {
-              res.status(200).json({
-                success: true,
-                message: 'Documents retrieved',
-                data: documents
-              });
-            } else {
-              res.status(200).json({
-                success: true,
-                message: 'User doesn\'t have any document',
-                data: []
-              });
-            }
-          }).catch(() => {
-            res.status(500).json({
-              success: false,
-              message: 'Server error'
-            });
-          });
-        } else {
-          res.status(403).json({
-            success: false,
-            message: 'You\'re not authorised to do this'
-          });
-        }
+        res.status(403).json({
+          success: false,
+          message: 'You\'re not authorised to do this'
+        });
       }
     }).catch((err) => {
       res.status(500).json({

--- a/controllers/documents.js
+++ b/controllers/documents.js
@@ -97,17 +97,19 @@ const documentsCtr = {
               message: 'Document created',
               data: newDoc
             });
-          }).catch(() => {
+          }).catch((err) => {
             res.status(500).json({
               success: false,
-              message: 'Server error'
+              message: 'Server error',
+              error: err
             });
           });
         }
-      }).catch(() => {
+      }).catch((err) => {
         res.status(500).json({
           success: false,
-          message: 'Server error'
+          message: 'Server error',
+          error: err
         });
       });
     }
@@ -365,10 +367,11 @@ const documentsCtr = {
           });
         }
       }
-    }).catch(() => {
+    }).catch((err) => {
       res.status(500).json({
         success: false,
-        message: 'Server error'
+        message: 'Server error',
+        error: err
       });
     });
   }

--- a/controllers/helpers/docHelper.js
+++ b/controllers/helpers/docHelper.js
@@ -1,7 +1,8 @@
 const docHelper = {
   checkDocDetails: (req) => {
     const document = req.body;
-    if (!(document.title && document.content && document.access)) {
+    if (!(document.title && document.content && document.access &&
+      (document.access === 'public' || document.access === 'private' || document.access === 'role'))) {
       return false;
     }
     return true;

--- a/controllers/roles.js
+++ b/controllers/roles.js
@@ -12,10 +12,11 @@ const rolesCtr = {
           data: roles
         });
       })
-      .catch(() => {
+      .catch((err) => {
         res.status(500).json({
           success: false,
-          message: 'An error occured in the server'
+          message: 'An error occured in the server',
+          error: err
         });
       });
   },
@@ -31,7 +32,7 @@ const rolesCtr = {
         if (!role) {
           res.status(404).json({
             success: false,
-            message: 'role does not exist'
+            message: 'Role does not exist'
           });
         } else {
           res.status(200).json({
@@ -40,10 +41,11 @@ const rolesCtr = {
             data: role
           });
         }
-      }).catch(() => {
+      }).catch((err) => {
         res.status(500).json({
           success: false,
-          message: 'server error'
+          message: 'Server error',
+          error: err
         });
       });
   },
@@ -71,10 +73,11 @@ const rolesCtr = {
                 data: newRole
               });
             })
-            .catch(() => {
+            .catch((err) => {
               res.status(500).json({
                 success: false,
-                message: 'An error occured in the server'
+                message: 'Server error',
+                error: err
               });
             });
           } else {
@@ -99,7 +102,7 @@ const rolesCtr = {
         if (!role) {
           res.status(404).json({
             success: false,
-            message: 'role does not exist'
+            message: 'Role does not exist'
           });
         } else {
           models
@@ -114,17 +117,19 @@ const rolesCtr = {
                 success: true,
                 message: 'updated successfully'
               });
-            }).catch(() => {
+            }).catch((err) => {
               res.status(500).json({
                 success: false,
-                message: 'server error'
+                message: 'Server error',
+                error: err
               });
             });
         }
-      }).catch(() => {
+      }).catch((err) => {
         res.status(500).json({
           success: false,
-          message: 'server error'
+          message: 'Server error',
+          error: err
         });
       });
   },

--- a/controllers/roles.js
+++ b/controllers/roles.js
@@ -15,7 +15,7 @@ const rolesCtr = {
       .catch((err) => {
         res.status(500).json({
           success: false,
-          message: 'An error occured in the server',
+          message: 'Server error',
           error: err
         });
       });
@@ -24,11 +24,7 @@ const rolesCtr = {
     const roleId = req.params.id;
     models
       .Roles
-      .findOne({
-        where: {
-          id: roleId
-        }
-      }).then((role) => {
+      .findById(roleId).then((role) => {
         if (!role) {
           res.status(404).json({
             success: false,
@@ -94,11 +90,7 @@ const rolesCtr = {
     const roleId = req.params.id;
     models
       .Roles
-      .findOne({
-        where: {
-          id: roleId
-        }
-      }).then((role) => {
+      .findById(roleId).then((role) => {
         if (!role) {
           res.status(404).json({
             success: false,

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -87,19 +87,11 @@ const usersCtr = {
     const userId = req.params.id;
     const decoded = req.decoded;
 
-    models.Roles.findOne({
-      where: {
-        id: decoded.roleId
-      }
-    }).then((role) => {
+    models.Roles.findById(decoded.roleId).then((role) => {
       if (role) {
         if (decoded.id === Number(userId) || role.title === 'admin') {
           userModel
-            .findOne({
-              where: {
-                id: userId
-              }
-            }).then((user) => {
+            .findById(userId).then((user) => {
               if (user) {
                 res.status(200).json({
                   success: true,
@@ -132,11 +124,7 @@ const usersCtr = {
     const userId = req.params.id;
     const decoded = req.decoded;
 
-    models.Roles.findOne({
-      where: {
-        id: decoded.roleId
-      }
-    }).then((role) => {
+    models.Roles.findById(decoded.roleId).then((role) => {
       if (role) {
         if (decoded.id === Number(userId) || role.title === 'admin') {
           userModel.update(req.body, {

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -41,7 +41,7 @@ const usersCtr = {
         if (!role) {
           res.status(400)
             .json({
-              success: 'false',
+              success: false,
               message: 'Please select a valid role'
             });
         } else if (role.title === 'admin') {
@@ -51,7 +51,7 @@ const usersCtr = {
           if (decoded && decoded.roleId !== user.roleId) {
             res.status(403)
               .json({
-                success: 'false',
+                success: false,
                 message: 'You must be an admin user to create another admin user'
               });
             res.end();

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -39,54 +39,61 @@ const usersCtr = {
     } else {
       models.Roles.findById(user.roleId).then((role) => {
         if (!role) {
-          res.status(400)
+          return res.status(400)
             .json({
               success: false,
               message: 'Please select a valid role'
             });
         } else if (role.title === 'admin') {
           const token = req.headers['x-access-token'];
-          const decoded = jwt.verify(token, secret);
-
-          if (decoded && decoded.roleId !== user.roleId) {
-            res.status(403)
+          if (token) {
+            const decoded = jwt.verify(token, secret);
+            if (decoded && decoded.roleId !== user.roleId) {
+              return res.status(403)
+                .json({
+                  success: false,
+                  message: 'You must be an admin user to create another admin user'
+                });
+            }
+          } else {
+            return res.status(403)
               .json({
                 success: false,
-                message: 'You must be an admin user to create another admin user'
+                message: 'You must be authenticated to create an admin user'
               });
-            res.end();
           }
-        } else {
-          userModel
-            .findOne({
-              where: {
-                $or: [{ username: user.username }, { email: user.email }]
-              }
-            }).then((result) => {
-              if (!result) {
-                userModel
-                  .create(user)
-                  .then((newUser) => {
-                    res.status(201).json({
-                      success: true,
-                      message: 'User created',
-                      data: newUser
-                    });
-                  });
-              } else {
-                res.status(409).json({
-                  success: false,
-                  message: 'User already exists'
-                });
-              }
-            }).catch((err) => {
-              res.status(500).json({
-                success: false,
-                message: 'Server error',
-                error: err
-              });
-            });
         }
+        // else {
+        userModel
+          .findOne({
+            where: {
+              $or: [{ username: user.username }, { email: user.email }]
+            }
+          }).then((result) => {
+            if (!result) {
+              userModel
+                .create(user)
+                .then((newUser) => {
+                  res.status(201).json({
+                    success: true,
+                    message: 'User created',
+                    data: newUser
+                  });
+                });
+            } else {
+              res.status(409).json({
+                success: false,
+                message: 'User already exists'
+              });
+            }
+          }).catch((err) => {
+            res.status(500).json({
+              success: false,
+              message: 'Server error',
+              error: err
+            });
+          });
+        // }
       });
     }
   },

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -18,11 +18,12 @@ const usersCtr = {
             data: users
           });
       })
-      .catch(() => {
+      .catch((err) => {
         res.status(500)
           .json({
             success: false,
-            message: 'Server error'
+            message: 'Server error',
+            error: err
           });
       });
   },
@@ -71,10 +72,11 @@ const usersCtr = {
                 message: 'User already exists'
               });
             }
-          }).catch(() => {
+          }).catch((err) => {
             res.status(500).json({
               success: false,
-              message: 'Server error'
+              message: 'Server error',
+              error: err
             });
           });
       }
@@ -118,10 +120,11 @@ const usersCtr = {
           message: 'Role does not exist'
         });
       }
-    }).catch(() => {
+    }).catch((err) => {
       res.status(500).json({
         success: false,
         message: 'Server error',
+        error: err
       });
     });
   },
@@ -152,7 +155,7 @@ const usersCtr = {
             res.status(500).json({
               success: false,
               message: 'Update failed',
-              data: err
+              error: err
             });
           });
         } else {
@@ -167,10 +170,11 @@ const usersCtr = {
           message: 'Role does not exist'
         });
       }
-    }).catch(() => {
+    }).catch((err) => {
       res.status(500).json({
         success: false,
         message: 'Server error',
+        error: err
       });
     });
   },
@@ -199,10 +203,11 @@ const usersCtr = {
             message: 'User doesn\'t exist'
           });
         }
-      }).catch(() => {
+      }).catch((err) => {
         res.status(500).json({
           success: false,
-          message: 'Server error'
+          message: 'Server error',
+          error: err
         });
       });
     }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -103,28 +103,21 @@ const usersCtr = {
     const decoded = req.decoded;
 
     models.Roles.findById(decoded.roleId).then((role) => {
-      if (role) {
-        if (decoded.id === Number(userId) || role.title === 'admin') {
-          userModel
-            .findById(userId).then((user) => {
-              if (user) {
-                res.status(200).json({
-                  success: true,
-                  message: 'User retrieved',
-                  data: user
-                });
-              }
-            });
-        } else {
-          res.status(403).json({
-            success: false,
-            message: 'You\'re not allowed to perform this action'
+      if (decoded.id === Number(userId) || role.title === 'admin') {
+        userModel
+          .findById(userId).then((user) => {
+            if (user) {
+              res.status(200).json({
+                success: true,
+                message: 'User retrieved',
+                data: user
+              });
+            }
           });
-        }
       } else {
-        res.status(404).json({
+        res.status(403).json({
           success: false,
-          message: 'Role does not exist'
+          message: 'You\'re not allowed to perform this action'
         });
       }
     }).catch((err) => {
@@ -140,37 +133,30 @@ const usersCtr = {
     const decoded = req.decoded;
 
     models.Roles.findById(decoded.roleId).then((role) => {
-      if (role) {
-        if (decoded.id === Number(userId) || role.title === 'admin') {
-          userModel.update(req.body, {
-            where: {
-              id: userId
-            },
-            returning: true,
-            plain: true
-          }).then((updatedUser) => {
-            res.status(200).json({
-              success: true,
-              message: 'User detail update',
-              data: updatedUser[1].dataValues
-            });
-          }).catch((err) => {
-            res.status(500).json({
-              success: false,
-              message: 'Update failed',
-              error: err
-            });
+      if (decoded.id === Number(userId) || role.title === 'admin') {
+        userModel.update(req.body, {
+          where: {
+            id: userId
+          },
+          returning: true,
+          plain: true
+        }).then((updatedUser) => {
+          res.status(200).json({
+            success: true,
+            message: 'User detail update',
+            data: updatedUser[1].dataValues
           });
-        } else {
-          res.status(403).json({
+        }).catch((err) => {
+          res.status(500).json({
             success: false,
-            message: 'You\'re not allowed to perform this action'
+            message: 'Update failed',
+            error: err
           });
-        }
+        });
       } else {
-        res.status(404).json({
+        res.status(403).json({
           success: false,
-          message: 'Role does not exist'
+          message: 'You\'re not allowed to perform this action'
         });
       }
     }).catch((err) => {

--- a/middleware/authorisation.js
+++ b/middleware/authorisation.js
@@ -28,11 +28,12 @@ const authorize = (req, res, next) => {
           message: 'Invalid role'
         });
     }
-  }).catch(() => {
+  }).catch((err) => {
     res.status(500)
       .json({
         success: 'false',
-        message: 'server error'
+        message: 'Server error',
+        error: err
       });
   });
 };

--- a/middleware/authorisation.js
+++ b/middleware/authorisation.js
@@ -13,21 +13,21 @@ const authorize = (req, res, next) => {
       } else {
         res.status(403)
           .json({
-            success: 'false',
+            success: false,
             message: 'Not authorised to perform this action'
           });
       }
     } else {
       res.status(403)
         .json({
-          success: 'false',
+          success: false,
           message: 'Invalid role'
         });
     }
   }).catch((err) => {
     res.status(500)
       .json({
-        success: 'false',
+        success: false,
         message: 'Server error',
         error: err
       });

--- a/middleware/authorisation.js
+++ b/middleware/authorisation.js
@@ -6,11 +6,7 @@ const authorize = (req, res, next) => {
   const decoded = req.decoded;
   const roleId = decoded.roleId;
 
-  roleModel.findOne({
-    where: {
-      id: roleId
-    }
-  }).then((role) => {
+  roleModel.findById(roleId).then((role) => {
     if (role) {
       if (role.title === 'admin') {
         next();

--- a/tests/server/data/user-data.js
+++ b/tests/server/data/user-data.js
@@ -26,12 +26,21 @@ module.exports = {
     password: 'Password',
     roleId: 2
   },
-  // administatrive role
+  // administatrive user
   adminUser: {
     firstname: 'Terwase',
     lastname: 'Gberikon',
     username: 'mrgberikon',
     email: 'mrgberikon@gmail.com',
+    password: 'Pasword12345',
+    roleId: 1
+  },
+  // administrative user
+  adminUser2: {
+    firstname: 'Terwase',
+    lastname: 'Gberikon',
+    username: 'mrgberikon1',
+    email: 'mrgberikon1@gmail.com',
     password: 'Pasword12345',
     roleId: 1
   },

--- a/tests/server/roles.spec.js
+++ b/tests/server/roles.spec.js
@@ -103,7 +103,7 @@ describe('Roles', () => {
       .set('x-access-token', adminToken)
       .expect(404)
       .end((err, res) => {
-        expect(res.body.message).to.equal('role does not exist');
+        expect(res.body.message).to.equal('Role does not exist');
         done(err);
       });
   });
@@ -127,7 +127,7 @@ describe('Roles', () => {
       .send({ title: 'regular' })
       .expect(404)
       .end((err, res) => {
-        expect(res.body.message).to.equal('role does not exist');
+        expect(res.body.message).to.equal('Role does not exist');
         done(err);
       });
   });

--- a/tests/server/users.spec.js
+++ b/tests/server/users.spec.js
@@ -47,6 +47,41 @@ describe('User', () => {
       });
   });
 
+  it('non-authenticated users can\'t create an admin', (done) => {
+    api
+      .post('/api/users/')
+      .send(userData.adminUser2)
+      .expect(403)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('You must be authenticated to create an admin user');
+        done(err);
+      });
+  });
+
+  it('non-admin users can\'t create an admin', (done) => {
+    api
+      .post('/api/users/')
+      .set('x-access-token', normalToken)
+      .send(userData.adminUser2)
+      .expect(403)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('You must be an admin user to create another admin user');
+        done(err);
+      });
+  });
+
+  it('admin users can create another admin', (done) => {
+    api
+      .post('/api/users/')
+      .set('x-access-token', adminToken)
+      .send(userData.adminUser2)
+      .expect(201)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('User created');
+        done(err);
+      });
+  });
+
   it('should reject users with invalid roles', (done) => {
     api
       .post('/api/users/')
@@ -102,7 +137,7 @@ describe('User', () => {
       .set('x-access-token', adminToken)
       .expect(200)
       .end((err, res) => {
-        expect(res.body.data.length).to.equal(4);
+        expect(res.body.data.length).to.equal(5);
         done(err);
       });
   });

--- a/tests/server/users.spec.js
+++ b/tests/server/users.spec.js
@@ -47,6 +47,17 @@ describe('User', () => {
       });
   });
 
+  it('should reject users with invalid roles', (done) => {
+    api
+      .post('/api/users/')
+      .send(userData.invalidUser2)
+      .expect(400)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('Please select a valid role');
+        done(err);
+      });
+  });
+
   it('should not accept duplicate email address', (done) => {
     // duplicate email address
     api


### PR DESCRIPTION
### What does this PR do?
Implements the suggestions made by Ufedo Opaluwa during the second review of the checkpoint.

### Action points
* Send back an error message for every `catch` block.
* Make all `Server error` messages consistent.
* Validate `user` role during `user` creation.
* Remove check if `role` exists when any resource is been accessed as the `user` roles should have been validated during `user` creation.
* Use `findById` instead of `findOne({where: ...condition})` when searching for resource by `id`.
* Check if `access` field of `document` to be created actually has the right terms `public, private & role`.