### PR TITLE
Changes from 1st defence

### DIFF
--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -75,4 +75,20 @@ export default class AuthenticationController {
       });
     }
   }
+
+
+  /**
+    * Signout
+    *
+    * signout method that handles users signing out of the application
+   *
+   * @param  {Object} req express request object that is received from
+   * the requester
+   * @param  {Object} res express response object that gets sent back to
+   * the requester
+   * @return {null} doesn't return anything
+   */
+  signout(req, res) {
+
+  }
 }

--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -89,6 +89,9 @@ export default class AuthenticationController {
    * @return {null} doesn't return anything
    */
   signout(req, res) {
-
+    res.status(200).json({
+      success: true,
+      message: 'You have been logged out'
+    });
   }
 }

--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -55,13 +55,13 @@ export default class AuthenticationController {
               data: token
             });
           } else {
-            res.status(403).json({
+            res.status(401).json({
               success: false,
               message: 'Authentication failed: Wrong password'
             });
           }
         } else {
-          res.status(404).json({
+          res.status(401).json({
             success: false,
             message: 'Authentication failed: User not found'
           });

--- a/controllers/documents.js
+++ b/controllers/documents.js
@@ -145,9 +145,9 @@ export default class DocumentsController {
   }
 
   /**
-   * Show
+   * get
    *
-   * show method gets a document from the databse based on the id supplied
+   * get method gets a document from the databse based on the id supplied
    * to the method and the role of the requester
    *
    * @param  {Object} req express request object that is received from

--- a/controllers/documents.js
+++ b/controllers/documents.js
@@ -156,7 +156,7 @@ export default class DocumentsController {
    * the requester
    * @return {null} doesn't return anything
    */
-  show(req, res) {
+  get(req, res) {
     const decodedUser = req.decoded;
     const docId = req.params.id;
 

--- a/controllers/documents.js
+++ b/controllers/documents.js
@@ -43,16 +43,6 @@ export default class DocumentsController {
           }];
         }
 
-        if (role.title !== 'admin') {
-          dbQuery.where = dbQuery.where || {};
-          dbQuery.where.$or = [{
-            access: 'public'
-          }, {
-            ownerId: decodedUser.id
-          }];
-        }
-
-
         docModel.findAll(dbQuery)
           .then((documents) => {
             if (documents.length > 0) {

--- a/controllers/helpers/docHelper.js
+++ b/controllers/helpers/docHelper.js
@@ -51,6 +51,9 @@ export default class DocHelper {
     if (queries.indexOf('limit') > -1) {
       dbQuery.limit = reqQuery.limit;
     }
+    if (queries.indexOf('role') > -1) {
+      dbQuery.ownerRoleId = reqQuery.role;
+    }
     if (queries.indexOf('date') > -1) {
       const nextDate = new Date(reqQuery.date);
 

--- a/controllers/helpers/docHelper.js
+++ b/controllers/helpers/docHelper.js
@@ -17,9 +17,11 @@ export default class DocHelper {
    */
   static checkDocDetails(req) {
     const document = req.body;
-    if (!(document.title && document.content && document.access &&
-      (document.access === 'public' || document.access === 'private' || document.access === 'role'))) {
+    if (!(document.title && document.content)) {
       return false;
+    }
+    if (document.access && !(document.access === 'public' || document.access === 'private' || document.access === 'role')) {
+      return false
     }
     return true;
   }

--- a/controllers/helpers/userHelpers.js
+++ b/controllers/helpers/userHelpers.js
@@ -20,7 +20,7 @@ export default class userHelper{
   static checkDetails(req) {
     const user = req.body;
     if (!(user.firstname && user.lastname && user.username
-      && user.password && user.roleId && user.email)) {
+      && user.password && user.email)) {
       return false;
     }
     return true;

--- a/controllers/roles.js
+++ b/controllers/roles.js
@@ -49,7 +49,7 @@ export default class RoleController {
    * the requester
    * @return {null} doesn't return anything
    */
-  show(req, res) {
+  get(req, res) {
     const roleId = req.params.id;
     models
       .Roles
@@ -89,7 +89,7 @@ export default class RoleController {
   create(req, res) {
     const roleTitle = req.body.title || req.query.title;
     if (!roleTitle) {
-      res.status(403).json({
+      res.status(400).json({
         success: false,
         message: 'Title cannot be empty'
       });

--- a/controllers/roles.js
+++ b/controllers/roles.js
@@ -180,6 +180,33 @@ export default class RoleController {
   }
 
   delete(req, res) {
+    const roleId = req.params.id;
 
+    models
+      .Roles
+      .destroy({
+        where: {
+          id: roleId
+        }
+      })
+      .then((result) => {
+        if (result > 0) {
+          res.status(200).json({
+            success: true,
+            message: 'Role deleted'
+          });
+        } else {
+          res.status(404).json({
+            success: false,
+            message: 'Role doesn\'t exist'
+          });
+        }
+      }).catch((err) => {
+        res.status(500).json({
+          success: false,
+          message: 'Server error',
+          error: err
+        });
+      });
   }
 }

--- a/controllers/roles.js
+++ b/controllers/roles.js
@@ -39,9 +39,9 @@ export default class RoleController {
   }
 
   /**
-   * Show
+   * get
    *
-   * show method gets a role from the db depending on the id given in the link
+   * get method gets a role from the db depending on the id given in the link
    *
    * @param  {Object} req express request object that is received from
    * the requester

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -14,7 +14,6 @@ const userModel = models.Users;
   * controller class that handles actions to be taken out on the user resource
   */
 export default class UserController {
-
   /**
    * Index
    *
@@ -237,36 +236,45 @@ export default class UserController {
    */
   delete(req, res) {
     const userId = req.params.id;
+    const decoded = req.decoded;
 
-    if (userId === req.decoded.id) {
-      res.status(403).json({
-        success: false,
-        message: 'You\'re not allowed to perform this action'
-      });
-    } else {
-      userModel.destroy({
-        where: {
-          id: userId
-        }
-      }).then((result) => {
-        if (result > 0) {
-          res.status(200).json({
-            success: true,
-            message: 'User deleted'
-          });
-        } else {
-          res.status(404).json({
+    models.Roles.findById(decoded.roleId).then((role) => {
+      if (decoded.id === Number(userId) || role.title === 'admin') {
+        userModel.destroy({
+          where: {
+            id: userId
+          }
+        }).then((result) => {
+          if (result > 0) {
+            res.status(200).json({
+              success: true,
+              message: 'User deleted'
+            });
+          } else {
+            res.status(404).json({
+              success: false,
+              message: 'User doesn\'t exist'
+            });
+          }
+        }).catch((err) => {
+          res.status(500).json({
             success: false,
-            message: 'User doesn\'t exist'
+            message: 'Server error',
+            error: err
           });
-        }
-      }).catch((err) => {
-        res.status(500).json({
-          success: false,
-          message: 'Server error',
-          error: err
         });
+      } else {
+        res.status(403).json({
+          success: false,
+          message: 'Not authorised to perform this action'
+        });
+      }
+    }).catch((err) => {
+      res.status(500).json({
+        success: false,
+        message: 'Server error',
+        error: err
       });
-    }
+    });
   }
 }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -140,7 +140,7 @@ export default class UserController {
    * the requester
    * @return {null} doesn't return anything
    */
-  show(req, res) {
+  get(req, res) {
     const userId = req.params.id;
     const decoded = req.decoded;
 

--- a/feedback.md
+++ b/feedback.md
@@ -1,0 +1,13 @@
+* Newly created users should have a default role (Which would be the normal role)
+* Write a test that validates a document has a property “access” set as “public” by default (Implement this test)
+* Put an offset time for each of the document's createdAt field
+* Move getting document by data as a query to search spec
+* Test the published date of returned Documents
+* remove duplicate code in index function of document controller
+** Preference for PascalCase
+* Change show to getting
+* Implement delete method for roles
+* Move check for authentication and authorisation to the mount point
+* Change 403 status code on create role method
+* Unauthorised in signin method
+* Implement signout

--- a/feedback.md
+++ b/feedback.md
@@ -1,5 +1,5 @@
 {
-  * Newly created users should have a default role (Which would be the normal role)
+  * Newly created users should have a default role (Which would be the normal role) (done)
   * Write a test that validates a document has a property “access” set as “public” by default (Implement this test)
   * Put an offset time for each of the document's createdAt field
   * Test the published date of returned Documents
@@ -7,7 +7,7 @@
 
 ** Preference for PascalCase
 * Move check for authentication and authorisation to the mount point
-* Implement signout
+* Implement signout (done)
 * Implement Implement user deleting yourself (done)
 * Unauthorised in signin method (done)
 * Change show to get (done)

--- a/feedback.md
+++ b/feedback.md
@@ -1,7 +1,7 @@
 {
   * Newly created users should have a default role (Which would be the normal role) (done)
-  * Write a test that validates a document has a property “access” set as “public” by default (Implement this test)
-  * Put an offset time for each of the document's createdAt field
+  * Write a test that validates a document has a property “access” set as “public” by default (Implement this test) (done)
+  * Put an offset time for each of the document's createdAt field (not doing).
   * Test the published date of returned Documents
 }
 

--- a/feedback.md
+++ b/feedback.md
@@ -1,13 +1,16 @@
-* Newly created users should have a default role (Which would be the normal role)
-* Write a test that validates a document has a property “access” set as “public” by default (Implement this test)
-* Put an offset time for each of the document's createdAt field
-* Move getting document by data as a query to search spec
-* Test the published date of returned Documents
-* remove duplicate code in index function of document controller
+{
+  * Newly created users should have a default role (Which would be the normal role)
+  * Write a test that validates a document has a property “access” set as “public” by default (Implement this test)
+  * Put an offset time for each of the document's createdAt field
+  * Test the published date of returned Documents
+}
+
 ** Preference for PascalCase
-* Change show to get (done)
-* Implement delete method for roles - Done
 * Move check for authentication and authorisation to the mount point
-* Change 403 status code on create role method (done)
-* Unauthorised in signin method (done)
 * Implement signout
+* Unauthorised in signin method (done)
+* Change show to get (done)
+* Implement delete method for roles (done)
+* remove duplicate code in index function of document controller (done)
+* Move getting document by data as a query to search spec (done)
+* Change 403 status code on create role method (done)

--- a/feedback.md
+++ b/feedback.md
@@ -4,7 +4,6 @@
   * Test the published date of returned Documents(done)
 }
 
-** Preference for PascalCase
 * Move check for authentication and authorisation to the mount point
 * Implement signout (done)
 * Implement Implement user deleting yourself (done)

--- a/feedback.md
+++ b/feedback.md
@@ -8,6 +8,7 @@
 ** Preference for PascalCase
 * Move check for authentication and authorisation to the mount point
 * Implement signout
+* Implement Implement user deleting yourself (done)
 * Unauthorised in signin method (done)
 * Change show to get (done)
 * Implement delete method for roles (done)

--- a/feedback.md
+++ b/feedback.md
@@ -1,8 +1,7 @@
 {
   * Newly created users should have a default role (Which would be the normal role) (done)
   * Write a test that validates a document has a property “access” set as “public” by default (Implement this test) (done)
-  * Put an offset time for each of the document's createdAt field (not doing).
-  * Test the published date of returned Documents
+  * Test the published date of returned Documents(done)
 }
 
 ** Preference for PascalCase

--- a/feedback.md
+++ b/feedback.md
@@ -5,9 +5,9 @@
 * Test the published date of returned Documents
 * remove duplicate code in index function of document controller
 ** Preference for PascalCase
-* Change show to getting
-* Implement delete method for roles
+* Change show to get (done)
+* Implement delete method for roles - Done
 * Move check for authentication and authorisation to the mount point
-* Change 403 status code on create role method
-* Unauthorised in signin method
+* Change 403 status code on create role method (done)
+* Unauthorised in signin method (done)
 * Implement signout

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -32,7 +32,7 @@ export default class Authentication {
     if (token) {
       jwt.verify(token, secret, (err, decoded) => {
         if (err) {
-          res.status(403).json({
+          res.status(401).json({
             success: false,
             message: 'Invalid token'
           });
@@ -42,7 +42,7 @@ export default class Authentication {
         }
       });
     } else {
-      return res.status(403).send({
+      return res.status(401).send({
         success: false,
         message: 'Token not provided'
       });

--- a/migrations/20161105175521-create-users.js
+++ b/migrations/20161105175521-create-users.js
@@ -32,6 +32,7 @@ module.exports = {
       },
       roleId: {
         type: Sequelize.INTEGER,
+        defaultValue: 2,
         allowNull: false
       },
       createdAt: {

--- a/migrations/20161105190614-create-documents.js
+++ b/migrations/20161105190614-create-documents.js
@@ -22,6 +22,7 @@ module.exports = {
       },
       access: {
         allowNull: false,
+        defaultValue: "public",
         type: Sequelize.STRING
       },
       ownerRoleId: {

--- a/models/documents.js
+++ b/models/documents.js
@@ -12,6 +12,7 @@ module.exports = function (sequelize, DataTypes) {
     },
     access: {
       type: DataTypes.STRING,
+      defaultValue: "public",
       allowNull: false
     },
     ownerRoleId: {

--- a/models/users.js
+++ b/models/users.js
@@ -29,6 +29,7 @@ module.exports = function(sequelize, DataTypes) {
     },
     roleId: {
       type: DataTypes.INTEGER,
+      defaultValue: 2,
       allowNull: false
     },
   }, {

--- a/routes/documents.js
+++ b/routes/documents.js
@@ -21,7 +21,7 @@ export default function documentRoutes(router) {
 
   router
     .route('/documents/:id')
-    .get(Authentication.checkAuthentication, DocCtr.show)
+    .get(Authentication.checkAuthentication, DocCtr.get)
     .put(Authentication.checkAuthentication, DocCtr.update)
     .delete(Authentication.checkAuthentication, DocCtr.delete);
 

--- a/routes/roles.js
+++ b/routes/roles.js
@@ -21,7 +21,7 @@ export default function roleRoutes(router) {
 
   router
     .route('/roles/:id')
-    .get(Authentication.checkAuthentication, Authorisation.checkAuthorisation, RoleCtr.show)
+    .get(Authentication.checkAuthentication, Authorisation.checkAuthorisation, RoleCtr.get)
     .put(Authentication.checkAuthentication, Authorisation.checkAuthorisation, RoleCtr.update)
     .delete(Authentication.checkAuthentication, Authorisation.checkAuthorisation, RoleCtr.delete);
 }

--- a/routes/roles.js
+++ b/routes/roles.js
@@ -23,5 +23,5 @@ export default function roleRoutes(router) {
     .route('/roles/:id')
     .get(Authentication.checkAuthentication, Authorisation.checkAuthorisation, RoleCtr.show)
     .put(Authentication.checkAuthentication, Authorisation.checkAuthorisation, RoleCtr.update)
-    .delete(RoleCtr.delete);
+    .delete(Authentication.checkAuthentication, Authorisation.checkAuthorisation, RoleCtr.delete);
 }

--- a/routes/users.js
+++ b/routes/users.js
@@ -16,6 +16,10 @@ const AuthController = new AuthenticationController();
  * @return {null} doesn't return anything
  */
 export default function userRoutes(router) {
+  // route that deals with user signin
+  router.post('/users/login', AuthController.signin);
+  router.get('/users/logout', Authentication.checkAuthentication, AuthController.signout);
+
   router
     .route('/users')
     .post(UserCtr.create)
@@ -26,8 +30,4 @@ export default function userRoutes(router) {
     .get(Authentication.checkAuthentication, UserCtr.get)
     .put(Authentication.checkAuthentication, UserCtr.update)
     .delete(Authentication.checkAuthentication, UserCtr.delete);
-
-  // route that deals with user signin
-  router.post('/users/login', AuthController.signin);
-  router.get('/users/logout', Authentication.checkAuthentication, AuthController.signout);
 }

--- a/routes/users.js
+++ b/routes/users.js
@@ -25,8 +25,9 @@ export default function userRoutes(router) {
     .route('/users/:id')
     .get(Authentication.checkAuthentication, UserCtr.get)
     .put(Authentication.checkAuthentication, UserCtr.update)
-    .delete(Authentication.checkAuthentication, Authorisation.checkAuthorisation, UserCtr.delete);
+    .delete(Authentication.checkAuthentication, UserCtr.delete);
 
   // route that deals with user signin
   router.post('/users/login', AuthController.signin);
+  router.get('/users/logout', Authentication.checkAuthentication, AuthController.signout);
 }

--- a/routes/users.js
+++ b/routes/users.js
@@ -23,7 +23,7 @@ export default function userRoutes(router) {
 
   router
     .route('/users/:id')
-    .get(Authentication.checkAuthentication, UserCtr.show)
+    .get(Authentication.checkAuthentication, UserCtr.get)
     .put(Authentication.checkAuthentication, UserCtr.update)
     .delete(Authentication.checkAuthentication, Authorisation.checkAuthorisation, UserCtr.delete);
 

--- a/test/server/authentication.spec.js
+++ b/test/server/authentication.spec.js
@@ -28,7 +28,7 @@ describe('User authentication', () => {
         username: userData.normalUser1.username,
         password: 'wrongpassword'
       })
-      .expect(403)
+      .expect(401)
       .end((err, res) => {
         expect(res.body.success).to.equal(false);
         expect(res.body.message).to.equal('Authentication failed: Wrong password');
@@ -59,7 +59,7 @@ describe('User authentication', () => {
         username: userData.invalidUSer1.username,
         password: userData.invalidUSer1.password
       })
-      .expect(404)
+      .expect(401)
       .end((err, res) => {
         expect(res.body.success).to.equal(false);
         expect(res.body.message).to.equal('Authentication failed: User not found');

--- a/test/server/authentication.spec.js
+++ b/test/server/authentication.spec.js
@@ -5,6 +5,7 @@ import userData from './data/user-data';
 
 const api = supertest(server);
 const expect = chai.expect;
+let signinToken;
 
 describe('User authentication', () => {
   it('should expect all fields to be filled', (done) => {
@@ -48,6 +49,7 @@ describe('User authentication', () => {
         expect(res.body.success).to.equal(true);
         expect(res.body.message).to.equal('Authentication successful');
         expect(res.body).to.have.property('data');
+        signinToken = res.body.data;
         done(err);
       });
   });
@@ -63,6 +65,29 @@ describe('User authentication', () => {
       .end((err, res) => {
         expect(res.body.success).to.equal(false);
         expect(res.body.message).to.equal('Authentication failed: User not found');
+        done(err);
+      });
+  });
+
+  it('should return a message on signout for registered users', (done) => {
+    api
+      .get('/api/users/logout')
+      .set('x-access-token', signinToken)
+      .expect(200)
+      .end((err, res) => {
+        // expect(res.body.success).to.equal(true);
+        expect(res.body.message).to.equal('You have been logged out');
+        done(err);
+      });
+  });
+
+  it('should reject signout request from unregistered users', (done) => {
+    api
+      .get('/api/users/logout')
+      .expect(401)
+      .end((err, res) => {
+        expect(res.body.success).to.equal(false);
+        expect(res.body.message).to.equal('Token not provided');
         done(err);
       });
   });

--- a/test/server/data/document-data.js
+++ b/test/server/data/document-data.js
@@ -1,13 +1,16 @@
 const documentData = {
   documentx: {
     title: 'document x',
-    content: 'document x contents',
-    access: 'public'
+    content: 'document x contents'
   },
   documenty: {
     title: 'document y',
     content: 'document y contents',
     access: 'public'
+  },
+  documentz: {
+    title: 'document z',
+    content: 'document z contents'
   },
   invalidDocument: {
     title: 'document y',

--- a/test/server/data/role-data.js
+++ b/test/server/data/role-data.js
@@ -4,6 +4,9 @@ const roleData = {
   },
   invalidRole: {
     titles: 'guest'
+  },
+  roleToDelete: {
+    title: 'limited'
   }
 };
 

--- a/test/server/data/user-data.js
+++ b/test/server/data/user-data.js
@@ -5,8 +5,7 @@ const userData = {
     lastname: 'Olutola',
     username: 'adetolaraphael',
     email: 'oreofe.olutola@gmail.com',
-    password: 'Pasword1234',
-    roleId: 2
+    password: 'Pasword1234'
   },
   // user with normal role 2
   normalUser2: {

--- a/test/server/documents.spec.js
+++ b/test/server/documents.spec.js
@@ -58,7 +58,7 @@ describe('Document', () => {
     done();
   });
 
-  it('Only registered users can create documents', (done) => {
+  it('only registered users can create documents', (done) => {
     api
       .post('/api/documents/')
       .send(documentData.documenty)
@@ -69,7 +69,7 @@ describe('Document', () => {
       });
   });
 
-  it('All fields must be filled', (done) => {
+  it('all fields must be filled', (done) => {
     api
       .post('/api/documents/')
       .set('x-access-token', normalToken1)
@@ -81,7 +81,7 @@ describe('Document', () => {
       });
   });
 
-  it('Registered users can create documents', (done) => {
+  it('registered users can create documents', (done) => {
     api
       .post('/api/documents/')
       .set('x-access-token', normalToken1)
@@ -93,7 +93,7 @@ describe('Document', () => {
       });
   });
 
-  it('Should not allow creation of documents with duplicate titles', (done) => {
+  it('should not allow creation of documents with duplicate titles', (done) => {
     api
       .post('/api/documents/')
       .set('x-access-token', normalToken1)
@@ -114,6 +114,20 @@ describe('Document', () => {
       .end((err, res) => {
         expect(res.body.message).to.equal('Document created');
         expect(res.body.data).to.have.property('createdAt');
+        done(err);
+      });
+  });
+
+  it('should have a default access of public', (done) => {
+    api
+      .post('/api/documents/')
+      .set('x-access-token', normalToken2)
+      .send(documentData.documentz)
+      .expect(201)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('Document created');
+        expect(res.body.data).to.have.property('access');
+        expect(res.body.data.access).to.equal('public');
         done(err);
       });
   });
@@ -211,7 +225,7 @@ describe('Document', () => {
 
   it('non-existent documents should return 404', (done) => {
     api
-      .get('/api/documents/13')
+      .get('/api/documents/20')
       .set('x-access-token', adminToken)
       .expect(404)
       .end((err, res) => {
@@ -227,7 +241,19 @@ describe('Document', () => {
       .expect(200)
       .end((err, res) => {
         expect(res.body.message).to.equal('Documents retreived');
-        expect(res.body.data.length).to.equal(12);
+        expect(res.body.data.length).to.equal(13);
+        done(err);
+      });
+  });
+
+  it('documents should ordered by date', (done) => {
+    api
+      .get('/api/documents')
+      .set('x-access-token', adminToken)
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('Documents retreived');
+        expect(res.body.data[0].createdAt).gte(res.body.data[1].createdAt);
         done(err);
       });
   });
@@ -239,19 +265,19 @@ describe('Document', () => {
       .expect(200)
       .end((err, res) => {
         expect(res.body.message).to.equal('Documents retreived');
-        expect(res.body.data.length).to.equal(9);
+        expect(res.body.data.length).to.equal(10);
         done(err);
       });
   });
 
-  it('Document gotten can be limited', (done) => {
+  it('document gotten can be limited', (done) => {
     api
       .get('/api/documents?limit=5')
       .set('x-access-token', adminToken)
       .expect(200)
       .end((err, res) => {
         expect(res.body.message).to.equal('Documents retreived');
-        expect(res.body.data.length).to.equal(5);
+        expect(res.body.data.length).to.be.at.most(5);
         done(err);
       });
   });
@@ -263,8 +289,8 @@ describe('Document', () => {
       .expect(200)
       .end((err, res) => {
         expect(res.body.message).to.equal('Documents retreived');
-        expect(res.body.data.length).to.equal(6);
-        expect(res.body.data[0].id).to.equal(3);
+        expect(res.body.data.length).to.be.at.most(6);
+        expect(res.body.data[0].id).to.equal(11);
         done(err);
       });
   });

--- a/test/server/documents.spec.js
+++ b/test/server/documents.spec.js
@@ -62,7 +62,7 @@ describe('Document', () => {
     api
       .post('/api/documents/')
       .send(documentData.documenty)
-      .expect(403)
+      .expect(401)
       .end((err, res) => {
         expect(res.body.message).to.equal('Token not provided');
         done(err);

--- a/test/server/documents.spec.js
+++ b/test/server/documents.spec.js
@@ -269,23 +269,6 @@ describe('Document', () => {
       });
   });
 
-  it('date can be set for documents search', (done) => {
-    const d = new Date();
-    const day = d.getDate();
-    const month = d.getMonth() + 1;
-    const year = d.getFullYear();
-    const date = `${year}-${month}-${day}`;
-    api
-      .get(`/api/documents?limit=4&date=${date}`)
-      .set('x-access-token', adminToken)
-      .expect(200)
-      .end((err, res) => {
-        expect(res.body.message).to.equal('Documents retreived');
-        expect(res.body.data.length).to.be.at.most(4);
-        done(err);
-      });
-  });
-
   it('users should be able to update their document', (done) => {
     api
       .put('/api/documents/5')

--- a/test/server/roles.spec.js
+++ b/test/server/roles.spec.js
@@ -61,7 +61,7 @@ describe('Roles', () => {
       .post('/api/roles/')
       .set('x-access-token', adminToken)
       .send(roleData.invalidRole)
-      .expect(403)
+      .expect(400)
       .end((err, res) => {
         expect(res.body.message).to.equal('Title cannot be empty');
         done(err);

--- a/test/server/roles.spec.js
+++ b/test/server/roles.spec.js
@@ -3,6 +3,7 @@ import supertest from 'supertest';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import winston from 'winston';
+import request from 'superagent';
 import server from './../../index';
 import roleData from './data/role-data';
 import userData from './data/user-data';
@@ -137,6 +138,28 @@ describe('Roles', () => {
       });
   });
 
+  it('admin users should be able to delete a role', (done) => {
+    api
+      .delete('/api/roles/3')
+      .set('x-access-token', adminToken)
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('Role deleted');
+        done(err);
+      });
+  });
+
+  it('admin users shouldn\'t be able to delete a non-existent role', (done) => {
+    api
+      .delete('/api/roles/3')
+      .set('x-access-token', adminToken)
+      .expect(404)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('Role doesn\'t exist');
+        done(err);
+      });
+  });
+
   describe('Unauthorised users', () => {
     it('shouldn\'t be able to create new roles', (done) => {
       api
@@ -177,6 +200,17 @@ describe('Roles', () => {
         .put('/api/roles/2')
         .set('x-access-token', normalToken)
         .send({ title: 'regular' })
+        .expect(403)
+        .end((err, res) => {
+          expect(res.body.message).to.equal('Not authorised to perform this action');
+          done(err);
+        });
+    });
+
+    it('normal users shouldn\'t be able to delete a role', (done) => {
+      api
+        .delete('/api/roles/2')
+        .set('x-access-token', normalToken)
         .expect(403)
         .end((err, res) => {
           expect(res.body.message).to.equal('Not authorised to perform this action');

--- a/test/server/search.spec.js
+++ b/test/server/search.spec.js
@@ -1,0 +1,42 @@
+import chai from 'chai';
+import supertest from 'supertest';
+import request from 'superagent';
+import server from './../../index';
+import userData from './data/user-data';
+
+const api = supertest(server);
+const expect = chai.expect;
+
+let adminToken;
+
+describe('Search', () => {
+  before((done) => {
+    request
+      .post('http://localhost:8080/api/users/login/')
+      .send({
+        username: userData.adminUser.username,
+        password: userData.adminUser.password
+      })
+      .end((err, res) => {
+        adminToken = res.body.data;
+        done(err);
+      });
+  });
+
+  it('date can be set for documents search', (done) => {
+    const d = new Date();
+    const day = d.getDate();
+    const month = d.getMonth() + 1;
+    const year = d.getFullYear();
+    const date = `${year}-${month}-${day}`;
+    api
+      .get(`/api/documents?limit=4&date=${date}`)
+      .set('x-access-token', adminToken)
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('Documents retreived');
+        expect(res.body.data.length).to.be.at.most(4);
+        done(err);
+      });
+  });
+});

--- a/test/server/search.spec.js
+++ b/test/server/search.spec.js
@@ -39,4 +39,21 @@ describe('Search', () => {
         done(err);
       });
   });
+
+  it('role and date can be set for documents search', (done) => {
+    const d = new Date();
+    const day = d.getDate();
+    const month = d.getMonth() + 1;
+    const year = d.getFullYear();
+    const date = `${year}-${month}-${day}`;
+    api
+      .get(`/api/documents?limit=6&date=${date}&role=2`)
+      .set('x-access-token', adminToken)
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('Documents retreived');
+        expect(res.body.data.length).to.be.at.most(6);
+        done(err);
+      });
+  });
 });

--- a/test/server/users.spec.js
+++ b/test/server/users.spec.js
@@ -42,7 +42,7 @@ describe('User', () => {
       });
   });
 
-  it('should create a new user', (done) => {
+  it('should create a new user with default role', (done) => {
     api
       .post('/api/users/')
       .send(userData.normalUser1)
@@ -50,6 +50,7 @@ describe('User', () => {
       .end((err, res) => {
         expect(res.body.message).to.equal('User created');
         expect(res.body.data).to.have.property('id');
+        expect(res.body.data).to.have.property('roleId');
         done(err);
       });
   });
@@ -60,7 +61,7 @@ describe('User', () => {
       .send(userData.adminUser2)
       .expect(403)
       .end((err, res) => {
-        expect(res.body.message).to.equal('You must be authenticated to create an admin user');
+        expect(res.body.message).to.equal('You must be an admin user to create another admin user');
         done(err);
       });
   });
@@ -268,7 +269,7 @@ describe('User', () => {
       });
   });
 
-  it('normal users shouldn be able to delete themselves', (done) => {
+  it('normal users should be able to delete themselves', (done) => {
     api
       .delete('/api/users/5')
       .set('x-access-token', normalTokenToDelete)

--- a/test/server/users.spec.js
+++ b/test/server/users.spec.js
@@ -12,6 +12,7 @@ dotenv.config({ silent: true });
 
 let adminToken;
 let normalToken;
+let normalTokenToDelete;
 
 before(() => {
   adminToken = jwt.sign({ username: 'gberikon', roleId: 1 }, secret, {
@@ -20,6 +21,11 @@ before(() => {
   const normalUser = userData.normalUser3;
   normalUser.id = 2;
   normalToken = jwt.sign(normalUser, secret, {
+    expiresIn: '24h'
+  });
+  const normalUserToDelete = userData.normalUser2;
+  normalUserToDelete.id = 5;
+  normalTokenToDelete = jwt.sign(normalUserToDelete, secret, {
     expiresIn: '24h'
   });
 });
@@ -251,13 +257,24 @@ describe('User', () => {
       });
   });
 
-  it('normal users shouldn\'t be able to delete a user', (done) => {
+  it('normal users shouldn\'t be able to delete another user', (done) => {
     api
       .delete('/api/users/3')
       .set('x-access-token', normalToken)
       .expect(403)
       .end((err, res) => {
         expect(res.body.message).to.equal('Not authorised to perform this action');
+        done(err);
+      });
+  });
+
+  it('normal users shouldn be able to delete themselves', (done) => {
+    api
+      .delete('/api/users/5')
+      .set('x-access-token', normalTokenToDelete)
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('User deleted');
         done(err);
       });
   });

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -3,3 +3,4 @@ require('./server/roles.spec.js');
 require('./server/users.spec.js');
 require('./server/authentication.spec.js');
 require('./server/documents.spec.js');
+require('./server/search.spec.js');


### PR DESCRIPTION
### What does this PR do?
Make changes as noted by Kes during the 1st defence of the checkpoint.

### Action points
* Make users have a default role on creation if none is supplied.
* Make documents have a default access field on creation if none is supplied.
* Implement signout.
* Use 401 status code in signin instead of 403 on invalid signin parameters.
* Change show method to get method.
* Implement delete method for roles.
* Allow users to  delete themselves.
* Remove duplicate code in index function of document controller.
* Move getting document by date as a query to search spec.
* Change 403 status code on create role method.